### PR TITLE
Feat: Use web worker to bake SH

### DIFF
--- a/packages/atlas-algorithm/package.json
+++ b/packages/atlas-algorithm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/tools-atlas-algorithm",
-  "version": "1.0.0-beta.5",
+  "version": "1.2.0-alpha.0",
   "description": "图集打包工具的算法",
   "scripts": {
     "b:types": "tsc",

--- a/packages/atlas-browser/package.json
+++ b/packages/atlas-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/tools-atlas-browser",
-  "version": "1.0.0-beta.5",
+  "version": "1.2.0-alpha.0",
   "description": "图集打包工具的浏览器版本",
   "scripts": {
     "b:types": "tsc",

--- a/packages/atlas-lottie-browser/package.json
+++ b/packages/atlas-lottie-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/tools-atlas-lottie-browser",
-  "version": "1.0.0-beta.5",
+  "version": "1.2.0-alpha.0",
   "description": "Lottie 图集打包工具的浏览器版本",
   "scripts": {
     "b:types": "tsc",

--- a/packages/atlas-lottie/package.json
+++ b/packages/atlas-lottie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/tools-atlas-lottie",
-  "version": "1.0.0-beta.5",
+  "version": "1.2.0-alpha.0",
   "license": "MIT",
   "bin": {
     "galacean-atlas-lottie": "./bin/cli.js"

--- a/packages/atlas/package.json
+++ b/packages/atlas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/tools-atlas",
-  "version": "1.0.0-beta.5",
+  "version": "1.2.0-alpha.0",
   "license": "MIT",
   "bin": {
     "galacean-tool-atlas": "./bin/cli.js"

--- a/packages/baker/package.json
+++ b/packages/baker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/tools-baker",
-  "version": "1.0.0-beta.5",
+  "version": "1.2.0-alpha.0",
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/baker/src/SphericalHarmonics3Baker.ts
+++ b/packages/baker/src/SphericalHarmonics3Baker.ts
@@ -8,9 +8,6 @@ import { WorkerManager } from "./WorkerManager";
  * http://www.ppsloan.org/publications/StupidSH36.pdf
  */
 export class SphericalHarmonics3Baker {
-  private static _tempColor: Color = new Color();
-  private static _tempVector: Vector3 = new Vector3();
-
   /**
    * Bake from Cube texture and use WebWorker.
    * @param texture - Cube texture
@@ -73,7 +70,7 @@ export function RGBMToLinear(r: number, g: number, b: number, a: number, color: 
   color[3] = 1;
 }
 export const gammaToLinearSpace = Color.gammaToLinearSpace;
-export function addSH(direction: number[], color: number[], deltaSolidAngle: number, sh: number[]): void {
+export function addSH(direction: number[], color: number[], deltaSolidAngle: number, sh: Float32Array): void {
   const x = direction[0];
   const y = direction[1];
   const z = direction[2];

--- a/packages/baker/src/SphericalHarmonics3Baker.ts
+++ b/packages/baker/src/SphericalHarmonics3Baker.ts
@@ -1,8 +1,9 @@
 import { Color, SphericalHarmonics3, TextureCube, TextureCubeFace, Vector3 } from "@galacean/engine";
 import { DecodeMode } from "./enums/DecodeMode";
+import { WorkerManager } from "./WorkerManager";
 
 /**
- * Bake irradiance into spherical harmonics3.
+ * Bake irradiance into spherical harmonics3 and use WebWorker.
  * @remarks
  * http://www.ppsloan.org/publications/StupidSH36.pdf
  */
@@ -11,115 +12,212 @@ export class SphericalHarmonics3Baker {
   private static _tempVector: Vector3 = new Vector3();
 
   /**
-   * Bake from Cube texture.
+   * Bake from Cube texture and use WebWorker.
    * @param texture - Cube texture
    * @param out - SH3 for output
    * @param decodeMode - Mode of decoding texture cube, default DecodeMode.RGBM
    */
-  static fromTextureCubeMap(
+  static async fromTextureCube(
     texture: TextureCube,
     out: SphericalHarmonics3,
     decodeMode: DecodeMode = DecodeMode.RGBM
-  ): void {
-    out.scale(0);
-
+  ): Promise<SphericalHarmonics3> {
     const channelLength = 4;
     const textureSize = texture.width;
-    const data = new Uint8Array(textureSize * textureSize * channelLength); // read pixel always return rgba
-    const color = this._tempColor;
-    const direction = this._tempVector;
-    const texelSize = 2 / textureSize; // convolution is in the space of [-1, 1]
 
-    let solidAngleSum = 0; // ideal value is 4 * pi
+    // read pixel always return rgba
+    const dataPX = new Uint8Array(textureSize * textureSize * channelLength);
+    const dataNX = new Uint8Array(textureSize * textureSize * channelLength);
+    const dataPY = new Uint8Array(textureSize * textureSize * channelLength);
+    const dataNY = new Uint8Array(textureSize * textureSize * channelLength);
+    const dataPZ = new Uint8Array(textureSize * textureSize * channelLength);
+    const dataNZ = new Uint8Array(textureSize * textureSize * channelLength);
+    texture.getPixelBuffer(TextureCubeFace.PositiveX, 0, 0, textureSize, textureSize, 0, dataPX);
+    texture.getPixelBuffer(TextureCubeFace.NegativeX, 0, 0, textureSize, textureSize, 0, dataNX);
+    texture.getPixelBuffer(TextureCubeFace.PositiveY, 0, 0, textureSize, textureSize, 0, dataPY);
+    texture.getPixelBuffer(TextureCubeFace.NegativeY, 0, 0, textureSize, textureSize, 0, dataNY);
+    texture.getPixelBuffer(TextureCubeFace.PositiveZ, 0, 0, textureSize, textureSize, 0, dataPZ);
+    texture.getPixelBuffer(TextureCubeFace.NegativeZ, 0, 0, textureSize, textureSize, 0, dataNZ);
+    const result = await WorkerManager.calculateSHFromTextureCube(
+      dataPX,
+      dataNX,
+      dataPY,
+      dataNY,
+      dataPZ,
+      dataNZ,
+      textureSize,
+      decodeMode
+    );
+    out.copyFromArray(result);
+    return out;
+  }
+}
 
-    for (let faceIndex = 0; faceIndex < 6; faceIndex++) {
-      texture.getPixelBuffer(TextureCubeFace.PositiveX + faceIndex, 0, 0, textureSize, textureSize, 0, data);
-      let v = texelSize * 0.5 - 1;
-      for (let y = 0; y < textureSize; y++) {
-        let u = texelSize * 0.5 - 1;
-        for (let x = 0; x < textureSize; x++) {
-          const dataOffset = y * textureSize * channelLength + x * channelLength;
+export function RGBEToLinear(r: number, g: number, b: number, a: number, color: number[]) {
+  if (a === 0) {
+    color[0] = color[1] = color[2] = 0;
+    color[3] = 1;
+  } else {
+    const scale = Math.pow(2, a - 128) / 255;
+    color[0] = r * scale;
+    color[1] = g * scale;
+    color[2] = b * scale;
+    color[3] = 1;
+  }
+}
+export function RGBMToLinear(r: number, g: number, b: number, a: number, color: number[]) {
+  const scale = a / 13005; // (a * 5) / 255 / 255;
+  color[0] = r * scale;
+  color[1] = g * scale;
+  color[2] = b * scale;
+  color[3] = 1;
+}
+export const gammaToLinearSpace = Color.gammaToLinearSpace;
+export function addSH(direction: number[], color: number[], deltaSolidAngle: number, sh: number[]): void {
+  const x = direction[0];
+  const y = direction[1];
+  const z = direction[2];
+  const r = color[0] * deltaSolidAngle;
+  const g = color[1] * deltaSolidAngle;
+  const b = color[2] * deltaSolidAngle;
+  const bv0 = 0.282095; // basis0 = 0.886227
+  const bv1 = -0.488603 * y; // basis1 = -0.488603
+  const bv2 = 0.488603 * z; // basis2 = 0.488603
+  const bv3 = -0.488603 * x; // basis3 = -0.488603
+  const bv4 = 1.092548 * (x * y); // basis4 = 1.092548
+  const bv5 = -1.092548 * (y * z); // basis5 = -1.092548
+  const bv6 = 0.315392 * (3 * z * z - 1); // basis6 = 0.315392
+  const bv7 = -1.092548 * (x * z); // basis7 = -1.092548
+  const bv8 = 0.546274 * (x * x - y * y); // basis8 = 0.546274
 
-          switch (decodeMode) {
-            case DecodeMode.Linear:
-              color.set(data[dataOffset], data[dataOffset + 1], data[dataOffset + 2], 0);
-              break;
-            case DecodeMode.Gamma:
-              color.set(
-                Color.gammaToLinearSpace(data[dataOffset] / 255),
-                Color.gammaToLinearSpace(data[dataOffset + 1] / 255),
-                Color.gammaToLinearSpace(data[dataOffset + 2] / 255),
-                0
-              );
-              break;
-            case DecodeMode.RGBE:
-              this._RGBEToLinear(
-                data[dataOffset],
-                data[dataOffset + 1],
-                data[dataOffset + 2],
-                data[dataOffset + 3],
-                color
-              );
-              break;
-            case DecodeMode.RGBM:
-              this._RGBMToLinear(
-                data[dataOffset],
-                data[dataOffset + 1],
-                data[dataOffset + 2],
-                data[dataOffset + 3],
-                color
-              );
-              break;
-          }
+  (sh[0] += r * bv0), (sh[1] += g * bv0), (sh[2] += b * bv0);
 
-          switch (faceIndex) {
-            case TextureCubeFace.PositiveX:
-              direction.set(1, -v, -u);
-              break;
-            case TextureCubeFace.NegativeX:
-              direction.set(-1, -v, u);
-              break;
-            case TextureCubeFace.PositiveY:
-              direction.set(u, 1, v);
-              break;
-            case TextureCubeFace.NegativeY:
-              direction.set(u, -1, -v);
-              break;
-            case TextureCubeFace.PositiveZ:
-              direction.set(u, -v, 1);
-              break;
-            case TextureCubeFace.NegativeZ:
-              direction.set(-u, -v, -1);
-              break;
-          }
+  (sh[3] += r * bv1), (sh[4] += g * bv1), (sh[5] += b * bv1);
+  (sh[6] += r * bv2), (sh[7] += g * bv2), (sh[8] += b * bv2);
+  (sh[9] += r * bv3), (sh[10] += g * bv3), (sh[11] += b * bv3);
 
-          /**
-           * dA = cos = S / r = 4 / r
-           * dw = dA / r2 = 4 / r / r2
-           */
-          const solidAngle = 4 / (direction.length() * direction.lengthSquared());
-          solidAngleSum += solidAngle;
-          out.addLight(direction.normalize(), color, solidAngle);
-          u += texelSize;
-        }
-        v += texelSize;
+  (sh[12] += r * bv4), (sh[13] += g * bv4), (sh[14] += b * bv4);
+  (sh[15] += r * bv5), (sh[16] += g * bv5), (sh[17] += b * bv5);
+  (sh[18] += r * bv6), (sh[19] += g * bv6), (sh[20] += b * bv6);
+  (sh[21] += r * bv7), (sh[22] += g * bv7), (sh[23] += b * bv7);
+  (sh[24] += r * bv8), (sh[25] += g * bv8), (sh[26] += b * bv8);
+}
+export function scaleSH(array: Float32Array, scale: number): void {
+  const src = array;
+  (src[0] *= scale), (src[1] *= scale), (src[2] *= scale);
+  (src[3] *= scale), (src[4] *= scale), (src[5] *= scale);
+  (src[6] *= scale), (src[7] *= scale), (src[8] *= scale);
+  (src[9] *= scale), (src[10] *= scale), (src[11] *= scale);
+  (src[12] *= scale), (src[13] *= scale), (src[14] *= scale);
+  (src[15] *= scale), (src[16] *= scale), (src[17] *= scale);
+  (src[18] *= scale), (src[19] *= scale), (src[20] *= scale);
+  (src[21] *= scale), (src[22] *= scale), (src[23] *= scale);
+  (src[24] *= scale), (src[25] *= scale), (src[26] *= scale);
+}
+
+export function decodeFaceSH(
+  faceData: Uint8Array,
+  faceIndex: TextureCubeFace,
+  decodeMode: DecodeMode,
+  textureSize: number,
+  lastSolidAngleSum: number,
+  sh: Float32Array // length 27
+): number {
+  const channelLength = 4;
+  const texelSize = 2 / textureSize; // convolution is in the space of [-1, 1]
+  const color = [];
+  const direction = [];
+
+  let v = texelSize * 0.5 - 1;
+  let solidAngleSum = lastSolidAngleSum;
+
+  for (let y = 0; y < textureSize; y++) {
+    let u = texelSize * 0.5 - 1;
+    for (let x = 0; x < textureSize; x++) {
+      const dataOffset = y * textureSize * channelLength + x * channelLength;
+      switch (decodeMode) {
+        case 0:
+          color[0] = faceData[dataOffset];
+          color[1] = faceData[dataOffset + 1];
+          color[2] = faceData[dataOffset + 2];
+          color[3] = 0;
+          break;
+        case 1:
+          color[0] = gammaToLinearSpace(faceData[dataOffset] / 255);
+          color[1] = gammaToLinearSpace(faceData[dataOffset + 1] / 255);
+          color[2] = gammaToLinearSpace(faceData[dataOffset + 2] / 255);
+          color[3] = 0;
+          break;
+        case 2:
+          RGBEToLinear(
+            faceData[dataOffset],
+            faceData[dataOffset + 1],
+            faceData[dataOffset + 2],
+            faceData[dataOffset + 3],
+            color
+          );
+          break;
+        case 3:
+          RGBMToLinear(
+            faceData[dataOffset],
+            faceData[dataOffset + 1],
+            faceData[dataOffset + 2],
+            faceData[dataOffset + 3],
+            color
+          );
+          break;
       }
+
+      switch (faceIndex) {
+        case 0:
+          direction[0] = 1;
+          direction[1] = -v;
+          direction[2] = -u;
+          break;
+        case 1:
+          direction[0] = -1;
+          direction[1] = -v;
+          direction[2] = u;
+          break;
+        case 2:
+          direction[0] = u;
+          direction[1] = 1;
+          direction[2] = v;
+          break;
+        case 3:
+          direction[0] = u;
+          direction[1] = -1;
+          direction[2] = -v;
+          break;
+        case 4:
+          direction[0] = u;
+          direction[1] = -v;
+          direction[2] = 1;
+          break;
+        case 5:
+          direction[0] = -u;
+          direction[1] = -v;
+          direction[2] = -1;
+          break;
+      }
+
+      /**
+       * dA = cos = S / r = 4 / r
+       * dw = dA / r2 = 4 / r / r2
+       */
+      const lengthSquared = direction[0] * direction[0] + direction[1] * direction[1] + direction[2] * direction[2];
+      const directionLength = Math.sqrt(lengthSquared);
+      const solidAngle = 4 / (directionLength * lengthSquared);
+      // normalize
+      direction[0] /= directionLength;
+      direction[1] /= directionLength;
+      direction[2] /= directionLength;
+      solidAngleSum += solidAngle;
+      addSH(direction, color, solidAngle, sh);
+      u += texelSize;
     }
-
-    out.scale((4 * Math.PI) / solidAngleSum);
+    v += texelSize;
   }
 
-  private static _RGBEToLinear(r: number, g: number, b: number, a: number, out: Color) {
-    if (a === 0) {
-      out.set(0, 0, 0, 1);
-    } else {
-      const scale = Math.pow(2, a - 128) / 255;
-      out.set(r * scale, g * scale, b * scale, 1);
-    }
-  }
-
-  private static _RGBMToLinear(r: number, g: number, b: number, a: number, out: Color) {
-    const scale = a / 13005; // (a * 5) / 255 / 255;
-    out.set(r * scale, g * scale, b * scale, 1);
-  }
+  return solidAngleSum;
 }

--- a/packages/baker/src/WorkerManager.ts
+++ b/packages/baker/src/WorkerManager.ts
@@ -1,0 +1,139 @@
+import {
+  RGBEToLinear,
+  RGBMToLinear,
+  addSH,
+  decodeFaceSH,
+  scaleSH,
+  gammaToLinearSpace
+} from "./SphericalHarmonics3Baker";
+import { DecodeMode } from "./enums/DecodeMode";
+
+// Only open one worker for one task now.
+export class WorkerManager {
+  private static _callbacks: Record<
+    string,
+    {
+      resolve: (any) => void;
+    }
+  > = {};
+  private static _workerCache: Record<string, Worker> = {};
+  private static _taskID: number = 0;
+
+  static getWorker(functionList: Function[]): Worker {
+    const codeString = this.getWorkerCodeByFunctionList(functionList);
+    if (this._workerCache[codeString]) {
+      return this._workerCache[codeString];
+    }
+    const url = this.getWorkerURLByCode(codeString);
+    const worker = new Worker(url);
+    this._workerCache[codeString] = worker;
+
+    this.registerWorkerEvent(worker);
+    return worker;
+  }
+
+  static registerWorkerEvent(worker: Worker) {
+    worker.onmessage = (event) => {
+      const data = event.data;
+      const { type, taskID } = data;
+      switch (type) {
+        case "calculateSHFromTextureCube":
+          const info = this._callbacks[taskID];
+          const result: Array<number> = data.result;
+          // console.log("worker result:", result);
+          info.resolve(result);
+          break;
+      }
+    };
+  }
+
+  static getURLByWorker(worker: Worker): string {
+    for (let url in this._workerCache) {
+      if (this._workerCache[url] === worker) {
+        return url;
+      }
+    }
+  }
+
+  static getWorkerCodeByFunctionList(functionList: Function[]): string {
+    const onmessageCode = onmessageInWorker.toString();
+    const onmessageString = onmessageCode.substring(onmessageCode.indexOf("{") + 1, onmessageCode.lastIndexOf("}"));
+
+    const combineString = `
+      ${functionList.map((f) => f.toString()).join("\n")}
+      ${onmessageString}
+    `;
+
+    return combineString;
+  }
+
+  static getWorkerURLByCode(codeString: string): string {
+    const workerSourceURL = URL.createObjectURL(new Blob([codeString], { type: "application/javascript" }));
+    return workerSourceURL;
+  }
+
+  /**
+   * Bake from Cube texture and use WebWorker.
+   * @param texture - Cube texture
+   * @param out - SH3 for output
+   * @param decodeMode - Mode of decoding texture cube, default DecodeMode.RGBM
+   */
+  static calculateSHFromTextureCube(
+    dataPX: Uint8Array,
+    dataNX: Uint8Array,
+    dataPY: Uint8Array,
+    dataNY: Uint8Array,
+    dataPZ: Uint8Array,
+    dataNZ: Uint8Array,
+    textureSize: number,
+    decodeMode: DecodeMode
+  ): Promise<number[]> {
+    return new Promise((resolve) => {
+      const taskID = this._taskID++;
+      const worker = this.getWorker([RGBEToLinear, RGBMToLinear, gammaToLinearSpace, addSH, scaleSH, decodeFaceSH]);
+      this._callbacks[taskID] = { resolve };
+
+      worker.postMessage({
+        type: "calculateSHFromTextureCube",
+        taskID,
+        textureSize,
+        decodeMode,
+        dataPX,
+        dataNX,
+        dataPY,
+        dataNY,
+        dataPZ,
+        dataNZ
+      });
+    });
+  }
+}
+
+export function onmessageInWorker() {
+  self.onmessage = function onmessage(event) {
+    const data = event.data;
+    const { type, taskID } = data;
+
+    switch (type) {
+      case "calculateSHFromTextureCube":
+        const { decodeMode, textureSize, dataPX, dataNX, dataPY, dataNY, dataPZ, dataNZ } = data;
+        const sh = new Float32Array(27);
+        let solidAngleSum = 0;
+        solidAngleSum = decodeFaceSH(dataPX, 0, decodeMode, textureSize, solidAngleSum, sh);
+        solidAngleSum = decodeFaceSH(dataNX, 1, decodeMode, textureSize, solidAngleSum, sh);
+        solidAngleSum = decodeFaceSH(dataPY, 2, decodeMode, textureSize, solidAngleSum, sh);
+        solidAngleSum = decodeFaceSH(dataNY, 3, decodeMode, textureSize, solidAngleSum, sh);
+        solidAngleSum = decodeFaceSH(dataPZ, 4, decodeMode, textureSize, solidAngleSum, sh);
+        solidAngleSum = decodeFaceSH(dataNZ, 5, decodeMode, textureSize, solidAngleSum, sh);
+
+        scaleSH(sh, (4 * Math.PI) / solidAngleSum);
+
+        self.postMessage({
+          type: "calculateSHFromTextureCube",
+          taskID,
+          result: sh
+        });
+        break;
+    }
+  };
+}

--- a/packages/color-dilation/package.json
+++ b/packages/color-dilation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/tools-color-dilation",
-  "version": "1.0.0-beta.5",
+  "version": "1.2.0-alpha.0",
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/engine-tools/package.json
+++ b/packages/engine-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/tools",
-  "version": "1.0.0-beta.5",
+  "version": "1.2.0-alpha.0",
   "license": "MIT",
   "scripts": {
     "b:types": "tsc"


### PR DESCRIPTION
### 背景
IBL 烘焙主要耗时在于 SH 的计算，如下图烘焙1024分辨率为例：
![image](https://github.com/galacean/tools/assets/17639043/27cb4b62-b68d-47f2-9237-e729a20e2656)

### 解决方案
使用webworker去多线程烘焙 SH，可以大约节省500ms 的CPU堵塞时间：
![image](https://github.com/galacean/tools/assets/17639043/b01504b1-a54a-49dd-a150-b3b8c307f4a8)


### 其他
SH改为worker仍有耗时是因为 worker 里面解决不了引擎 texture 对象的解析，即从立方体的六个面读取纹素为 Uint8Array 数据，仍然需要在主线里面处理，如下代码，暂时没找到解决方法
![image](https://github.com/galacean/tools/assets/17639043/e772fc30-cdf6-426a-96ac-75717b335ec5)
