### PR TITLE
[codex] fix lottie empty atlas transform

### DIFF
--- a/packages/atlas-lottie-browser/src/index.ts
+++ b/packages/atlas-lottie-browser/src/index.ts
@@ -1,9 +1,17 @@
 import { pack } from "@galacean/tools-atlas-browser";
 
+function createEmptyAtlasFile() {
+  return JSON.stringify({
+    version: 0,
+    format: 1,
+    atlasItems: []
+  });
+}
+
 export async function transform(lottie, images, options = {}) {
   try {
     const jsonData = JSON.parse(lottie);
-    const { assets } = jsonData;
+    const assets = Array.isArray(jsonData.assets) ? jsonData.assets : [];
     const lottieImages = [];
     for (let i = 0, l = assets.length; i < l; i++) {
       const asset = assets[i];
@@ -14,6 +22,25 @@ export async function transform(lottie, images, options = {}) {
           name: asset.id,
           src: p
         });
+    }
+    // Some Lottie files are pure vector/text animations and do not contain image assets.
+    // Keep the EditorLottie asset shape stable by returning an empty atlas instead of failing packing.
+    if (lottieImages.length === 0) {
+      jsonData.assets = assets.filter((asset) => {
+        return !asset.p;
+      });
+      return {
+        code: 0,
+        msg: "打包成功！",
+        info: {
+          version: 0,
+          format: 1,
+          atlasItems: [],
+          imageFiles: [],
+          atlasFile: createEmptyAtlasFile(),
+          jsonFile: JSON.stringify(jsonData)
+        } as any
+      };
     }
     const res = await pack(lottieImages, {
       width: 2048,
@@ -28,8 +55,13 @@ export async function transform(lottie, images, options = {}) {
     jsonData.assets = assets.filter((asset) => {
       return !asset.p;
     });
-    // @ts-ignore
-    res.info.jsonFile = JSON.stringify(jsonData);
+    const atlasFile = JSON.stringify(res.info);
+    (res as any).info = {
+      ...res.info,
+      imageFiles: res.imageFiles || [],
+      atlasFile,
+      jsonFile: JSON.stringify(jsonData)
+    };
     return res;
   } catch (error) {
     return {

--- a/packages/atlas-lottie/src/index.js
+++ b/packages/atlas-lottie/src/index.js
@@ -53,6 +53,7 @@ module.exports = async function transform(lottiePath, imagesPath, options = {}) 
 
     const { nm, assets } = data;
     const lottieAssets = Array.isArray(assets) ? assets : [];
+    const hasImageAssets = lottieAssets.some((asset) => asset.p);
     const { output } = options;
 
     const spritesDir = output ? `${output}/.sprites` : path.resolve(`.sprites`);
@@ -86,6 +87,13 @@ module.exports = async function transform(lottiePath, imagesPath, options = {}) 
     }
 
     if (images.length === 0) {
+      if (hasImageAssets) {
+        return {
+          code: 11,
+          msg: "No image files found for lottie image assets"
+        };
+      }
+
       if (fs.existsSync(spritesDir)) {
         fs.rmSync(spritesDir, { recursive: true, force: true });
       }

--- a/packages/atlas-lottie/src/index.js
+++ b/packages/atlas-lottie/src/index.js
@@ -16,11 +16,28 @@ function createImage(asset, dir) {
   return name;
 }
 
-module.exports = async function transform(
-  lottiePath,
-  imagesPath,
-  options = {}
-) {
+function createEmptyAtlas() {
+  return {
+    version: 0,
+    format: 1,
+    atlasItems: []
+  };
+}
+
+function ensureDir(dir) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function writeLottieJson(data, dir, nm) {
+  ensureDir(dir);
+  const jsonFilePath = `${dir}/${nm}.json`;
+  fs.writeFileSync(jsonFilePath, JSON.stringify(data));
+  return jsonFilePath;
+}
+
+module.exports = async function transform(lottiePath, imagesPath, options = {}) {
   let rawData, data;
 
   if (lottiePath.startsWith("http://") || lottiePath.startsWith("https://")) {
@@ -35,6 +52,7 @@ module.exports = async function transform(
     }
 
     const { nm, assets } = data;
+    const lottieAssets = Array.isArray(assets) ? assets : [];
     const { output } = options;
 
     const spritesDir = output ? `${output}/.sprites` : path.resolve(`.sprites`);
@@ -54,8 +72,8 @@ module.exports = async function transform(
         fs.mkdirSync(dir);
       }
 
-      for (let i = 0, l = assets.length; i < l; i++) {
-        const asset = assets[i];
+      for (let i = 0, l = lottieAssets.length; i < l; i++) {
+        const asset = lottieAssets[i];
 
         // sprite assets
         if (asset.p) {
@@ -67,9 +85,33 @@ module.exports = async function transform(
       }
     }
 
+    if (images.length === 0) {
+      if (fs.existsSync(spritesDir)) {
+        fs.rmSync(spritesDir, { recursive: true, force: true });
+      }
+
+      data.assets = lottieAssets.filter((asset) => {
+        return !asset.p;
+      });
+
+      const atlasFilePath = `${dir}/${nm}.atlas`;
+      ensureDir(dir);
+      fs.writeFileSync(atlasFilePath, JSON.stringify(createEmptyAtlas()));
+
+      const jsonFilePath = writeLottieJson(data, dir, nm);
+      return {
+        code: 0,
+        msg: "Pack atlas success!",
+        info: {
+          atlasFile: atlasFilePath,
+          jsonFile: jsonFilePath
+        }
+      };
+    }
+
     const res = await atlasTool.pack(images, {
       output: `${dir}/${nm}`,
-      ...options,
+      ...options
     });
 
     if (res.code !== 0) {
@@ -78,7 +120,7 @@ module.exports = async function transform(
     }
 
     if (fs.existsSync(spritesDir)) {
-      fs.rmdirSync(spritesDir, { recursive: true });
+      fs.rmSync(spritesDir, { recursive: true, force: true });
     }
 
     // Rewrite lottie json file
@@ -86,8 +128,7 @@ module.exports = async function transform(
       return !asset.p;
     });
 
-    const jsonFilePath = `${dir}/${nm}.json`;
-    fs.writeFileSync(jsonFilePath, JSON.stringify(data));
+    const jsonFilePath = writeLottieJson(data, dir, nm);
 
     res.info.jsonFile = jsonFilePath;
 
@@ -97,7 +138,7 @@ module.exports = async function transform(
   } catch (error) {
     return {
       code: 11,
-      msg: "Parse lottie file error",
+      msg: "Parse lottie file error"
     };
   }
 };


### PR DESCRIPTION
## Summary

Fix Lottie atlas conversion for animations that do not contain image assets. Some Lottie files, including text-only or vector/precomp-only animations, have no `assets[*].p` image entries. The previous atlas-lottie transform passed an empty image list into atlas packing, which failed and surfaced in the editor as `Parse lottie file error` during import.

This change treats zero-image Lottie files as valid input. The browser transform now returns a successful result with an empty Galacean atlas, the rewritten Lottie JSON, and the same `info.atlasFile` / `info.jsonFile` / `info.imageFiles` shape expected by the editor upload path. The Node transform now writes an empty `.atlas` file and the rewritten `.json` file for the same case. It also normalizes missing `assets` to an empty array and replaces deprecated recursive `rmdirSync` cleanup with `rmSync`.

## User Impact

Users can import Lottie animations that contain only text, precomps, null layers, or other non-image content without being blocked by atlas packing. Existing image-based Lottie atlas packing continues through the normal pack path.

## Validation

- `pnpm --filter @galacean/tools-atlas-lottie-browser run b:types`
- Ran the browser transform against `/Users/zhanyingwei/Downloads/gz/1782978627140_data.json` and verified `code: 0`, empty `atlasItems`, empty `imageFiles`, and generated `atlasFile` / `jsonFile` strings.
- Ran the Node transform against the same Lottie file and verified it writes an empty `.atlas` and rewritten `.json` file.
